### PR TITLE
Fix unicode errors

### DIFF
--- a/rest_framework_tus/middleware.py
+++ b/rest_framework_tus/middleware.py
@@ -127,7 +127,7 @@ class TusMiddleware(object):
             key, value = key_value_pair.split(' ')
 
             # Store data
-            upload_metadata[key] = decode_base64(value.encode('utf-8')).decode('ascii')
+            upload_metadata[key] = decode_base64(value.encode('ascii')).decode('utf-8')
 
         # Set upload_metadata
         setattr(request, constants.UPLOAD_METADATA_FIELD_NAME, upload_metadata)

--- a/rest_framework_tus/utils.py
+++ b/rest_framework_tus/utils.py
@@ -2,28 +2,27 @@
 from __future__ import unicode_literals
 
 import os
+import six
 
-import copy
 import tempfile
 import hashlib
 
 from .compat import encode_base64
 
 
-def encode_base64_to_string(string_value):
+def encode_base64_to_string(data):
     """
-    Helper to encode a string or bytes value to a base64 string
+    Helper to encode a string or bytes value to a base64 string as bytes
 
-    :param six.text_types string_value:
-    :return str:
+    :param six.text_types data:
+    :return six.binary_type:
     """
-    data = copy.copy(string_value)
 
-    if not isinstance(data, bytes):
-        if isinstance(data, str):
+    if not isinstance(data, six.binary_type):
+        if isinstance(data, six.text_type):
             data = data.encode('utf-8')
         else:
-            data = str(data).encode('utf-8')
+            data = six.text_type(data).encode('utf-8')
 
     return encode_base64(data).decode('ascii').rstrip('\n')
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ setup(
         'Django>=1.8,<=1.11',
         'djangorestframework>=3.5.4',
         'jsonfield>=2.0.0',
-        'django-fsm==2.6.0'
+        'django-fsm==2.6.0',
+        'six>=1.11.0',
     ],
     license="MIT",
     zip_safe=False,

--- a/tests/tests/test_views.py
+++ b/tests/tests/test_views.py
@@ -97,7 +97,8 @@ class ViewTests(APITestCase):
             'Tus-Resumable': tus_api_version,
             'Upload-Defer-Length': 1,
             'Upload-Metadata': encode_upload_metadata({
-                'filename': 'test_file.jpg'
+                # Make sure non-ASCII characters are supported (regression)
+                'filename': 'test_file_٩(-̮̮̃-̃)۶ ٩(●̮̮̃•̃)۶ ٩(͡๏̯͡๏)۶ ٩(-̮̮̃•̃).jpg'
             })
         }
 
@@ -112,7 +113,7 @@ class ViewTests(APITestCase):
 
         # Validate upload
         assert upload.upload_length == -1
-        assert upload.filename == 'test_file.jpg'
+        assert upload.filename == 'test_file_٩(-̮̮̃-̃)۶ ٩(●̮̮̃•̃)۶ ٩(͡๏̯͡๏)۶ ٩(-̮̮̃•̃).jpg'
 
         # Validate response headers
         assert 'Tus-Resumable' in result

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,9 @@ commands =
     codecov -e TOXENV
 deps =
     django-18: Django>=1.8,<1.9
+    django-18: djangorestframework>=3.5.4,<3.6
     django-19: Django>=1.9,<1.10
+    django-19: djangorestframework>=3.5.4,<3.6
     django-110: Django>=1.10,<1.11
     django-111: Django>=1.11
     -r{toxinidir}/requirements_test.txt


### PR DESCRIPTION
When uploading a file whose filename contains weird (non-latin, unicode) characters, drf-tus crashes with a UnicodeDecodeError. This PR fixes this and modified the test in such a way that a more challenging filename is sent in the metadata.